### PR TITLE
Fixes tuple index out of range

### DIFF
--- a/safeway-coupons
+++ b/safeway-coupons
@@ -192,9 +192,9 @@ class safeway():
         rsp = self._run_request(url, headers=headers)
         coupon_data = json.loads(rsp.content.decode('UTF-8'))
         coupon_detail = coupon_data.get('offerDetail', {})
-        title = '{} {} {}'.format((coupon_detail.get('titleDsc1', ''),
+        title = '{} {} {}'.format(coupon_detail.get('titleDsc1', ''),
                                    coupon_detail.get('titleDsc2', ''),
-                                   coupon_detail.get('prodDsc1', ''))).strip()
+                                   coupon_detail.get('prodDsc1', '')).strip()
         if section == 'PD':
             detail = '{} {}'.format(coupon_detail.get('priceTitle1', ''),
                                     coupon_detail.get('priceValue1', ''))


### PR DESCRIPTION
I kept getting these errors:

> Exception clipping coupons: tuple index out of range
Traceback (most recent call last):
  File "/home/fwiffo/scripts/safeway-coupons/safeway-coupons", line 298, in _clip_coupons
    'CC')
  File "/home/fwiffo/scripts/safeway-coupons/safeway-coupons", line 197, in _get_coupon_details
    coupon_detail.get('prodDsc1', ''))).strip()
IndexError: tuple index out of range

through trial and error, this seemed to fix it