### PR TITLE
Update project template cruft, dependencies

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/smkent/cookie-python",
-  "commit": "4fe836a1166d38f1e6aab9fba38d7a5bfce95213",
+  "commit": "41468ddddfec6517d6eb5f1df9eb8adf05e5873b",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,15 @@ repos:
       - flake8-pyproject
       - flake8-simplify
       - pep8-naming
+  - repo: https://github.com/pycqa/autoflake
+    rev: v2.0.1
+    hooks:
+    - id: autoflake
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    - id: pyupgrade
+      args: ["--keep-runtime-typing"]
   - repo: local
     hooks:
     - id: mypy

--- a/poetry.lock
+++ b/poetry.lock
@@ -1219,14 +1219,14 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "setuptools"
-version = "67.3.3"
+version = "67.4.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.3-py3-none-any.whl", hash = "sha256:9d3de8591bd6f6522594406fa46a6418eabd0562dacb267f8556675762801514"},
-    {file = "setuptools-67.3.3.tar.gz", hash = "sha256:ed4e75fafe103c79b692f217158ba87edf38d31004b9dbc1913debb48793c828"},
+    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
+    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["poetry-core>=1.2.0", "poetry-dynamic-versioning"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "safeway-coupons"


### PR DESCRIPTION
Applied updates from upstream project template commits:

https://github.com/smkent/cookie-python/compare/4fe836a1166d38f1e6aab9fba38d7a5bfce95213...41468ddddfec6517d6eb5f1df9eb8adf05e5873b

```
*   41468dd Merge pull request #94 from smkent/pyupgrade-keep-runtime-typing
|\  
| * 82b8568 Add --keep-runtime-typing to pyupgrade args
|/  
*   c83e9f4 Merge pull request #93 from smkent/manage-run-env
|\  
| * 4a161e4 Include PYTHON_KEYRING_BACKEND in repo run commands env
|/  
*   f6ac9b1 Merge pull request #92 from smkent/manage-update-pr-html-url
|\  
| * 30372bf Log opened PR's HTML URL instead of API URL in manage-cookie update
|/  
*   26efcfa Merge pull request #91 from smkent/manage-cookie
|\  
| * 91b6a89 Set PYTHON_KEYRING_BACKEND for poetry within unit tests
| * cf0f69a Apply automatic linting fixes
| * 582d618 Update project template cruft
|/  
*   c4899ec Merge pull request #90 from smkent/cruft-json-reset
|\  
| * f61ed02 Replace repo_reset with .cruft.json checkout
|/  
*   f5e42d6 Merge pull request #88 from smkent/autoflake-pyupgrade
|\  
| *   0d9d2ea Merge branch 'main' into autoflake-pyupgrade
| |\  
| |/  
|/|   
* |   a4fec71 Merge pull request #89 from smkent/fix-pyproject-version
|\ \  
| * | 62b1b68 Configure pyproject.toml build-backend for poetry-dynamic-versioning
| * | 85d5f74 Enable poetry-dynamic-versioning in pyproject.toml
| * | 549fc6e Update python-poetry action from template
| * | 1001f3e Add __version__.py
| * | 42f765f Remove fixed version string from pyproject.toml
|/ /  
| * d5f398c Add autoflake to pre-commit config
| * dda7315 Add pyupgrade to pre-commit config
|/  
*   429b0c8 Merge pull request #87 from smkent/manage-cookie-branch-name
|\  
| * 21aceda Tweak manage-cookie branch name
|/  
*   a3f5e77 Merge pull request #86 from smkent/update-cookie
|\  
| * a7ec03b Update dependencies
|/  
*   432da6a Merge pull request #85 from smkent/reference-self-current-dir
|\  
| * 3368613 Reference own template via current directory instead of URL
|/  
*   8ea43c8 Merge pull request #84 from smkent/skip-empty-updates
|\  
| * 0199bed Rework repository reset as a decorator
| * ee6e1de Reset repository working directory if skipping cruft update
| * 41940ba Capture output in git status command
| * 508f99d Skip cruft updates without template modifications
|/  
*   1b2d5ae Merge pull request #83 from smkent/ci-cd-pypi
|\  
| * 3366570 Enable publishing to PyPI
| * 77d2309 Apply CI/CD workflow updates from template
|/  
*   2c96f9e Merge pull request #82 from smkent/readme-badges
|\  
| *   5820d18 Merge remote-tracking branch 'origin/main' into readme-badges
| |\  
| |/  
|/|   
* |   c49a336 Merge pull request #81 from smkent/manage-main-loop
|\ \  
| * | 653af5b Move repository iteration loop to manage-cookie main function
|/ /  
| * 0de67eb Add PyPI badges to README.md
| * 01a9943 Add codecov badge to README.md
|/  
*   de9e951 Merge pull request #80 from smkent/github-api
|\  
| * 3343a19 Remove now-unused subprocess.run mock
| * d4fe333 Use PyGithub to create and locate releases
| * 77109a6 Mock PyGithub in unit tests, rename API token env var
| * b523f8e Use PyGithub for pull request creation, deletion
| * 7ef5da8 Use PyGithub to resolve repository from CLI params
| * 101cf80 Add pygithub
|/  
*   faaf379 Merge pull request #78 from smkent/replace-pr
|\  
| * 39a7465 Log opened PR URL
| * e89cc06 Close existing PR on update
| * 0305500 Don't check for existing branch on remote at clone time
* c21e45e Merge pull request #79 from smkent/release-log-fixup
* 163d273 Fix release log message wording
```

Updated project dependencies via `poetry update`:

Package operations: 0 installs, 1 update, 0 removals

- Updating setuptools (67.3.3 -> 67.4.0)