### PR TITLE
Improve crontab argument quoting, add `EXTRA_ARGS` Docker env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV SAFEWAY_ACCOUNT_MAIL_FROM=
 ENV SAFEWAY_ACCOUNT_MAIL_TO=
 ENV SAFEWAY_ACCOUNTS_FILE=
 ENV DEBUG_DIR="/debug"
+ENV EXTRA_ARGS=
 
 RUN DEBIAN_FRONTEND=noninteractive && \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub > /usr/share/keyrings/chrome.pub && \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ services:
   safeway-coupons:
     image: ghcr.io/smkent/safeway-coupons:latest
     environment:
-      CRON_SCHEDULE: "0 2 * * *"  # Run at 2:00 AM each day
+      CRON_SCHEDULE: "0 2 * * *"  # Run at 2:00 AM UTC each day
+      # TZ: Antarctica/McMurdo  # Optional time zone to use instead of UTC
       SMTPHOST: your.smtp.host
       SAFEWAY_ACCOUNT_USERNAME: your.safeway.account.email@example.com
       SAFEWAY_ACCOUNT_PASSWORD: very_secret
@@ -55,7 +56,8 @@ services:
   safeway-coupons:
     image: ghcr.io/smkent/safeway-coupons:latest
     environment:
-      CRON_SCHEDULE: "0 2 * * *"  # Run at 2:00 AM each day
+      CRON_SCHEDULE: "0 2 * * *"  # Run at 2:00 AM UTC each day
+      # TZ: Antarctica/McMurdo  # Optional time zone to use instead of UTC
       SMTPHOST: your.smtp.host
       SAFEWAY_ACCOUNTS_FILE: /accounts_file
       # EXTRA_ARGS: --debug  # Optional

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ services:
       SAFEWAY_ACCOUNT_PASSWORD: very_secret
       SAFEWAY_ACCOUNT_MAIL_FROM: your.email@example.com
       SAFEWAY_ACCOUNT_MAIL_TO: your.email@example.com
+      # EXTRA_ARGS: --debug  # Optional
     restart: unless-stopped
 ```
 
@@ -57,6 +58,7 @@ services:
       CRON_SCHEDULE: "0 2 * * *"  # Run at 2:00 AM each day
       SMTPHOST: your.smtp.host
       SAFEWAY_ACCOUNTS_FILE: /accounts_file
+      # EXTRA_ARGS: --debug  # Optional
     restart: unless-stopped
     volumes:
       - path/to/safeway_accounts_file:/accounts_file:ro

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -2,10 +2,10 @@
 
 set -ex
 
-args=
+args=${EXTRA_ARGS-}
 if [ -n "${SAFEWAY_ACCOUNTS_FILE}" ]; then
     echo "Using accounts file at ${SAFEWAY_ACCOUNTS_FILE} for configuration"
-    args="--accounts-config \"${SAFEWAY_ACCOUNTS_FILE}\""
+    args="${args} --accounts-config \"${SAFEWAY_ACCOUNTS_FILE}\""
 else
     echo "Using environment variables for configuration"
     if [ -z "${SAFEWAY_ACCOUNT_MAIL_TO}" ] \

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -5,7 +5,7 @@ set -ex
 args=
 if [ -n "${SAFEWAY_ACCOUNTS_FILE}" ]; then
     echo "Using accounts file at ${SAFEWAY_ACCOUNTS_FILE} for configuration"
-    args="--accounts-config ${SAFEWAY_ACCOUNTS_FILE}"
+    args="--accounts-config \"${SAFEWAY_ACCOUNTS_FILE}\""
 else
     echo "Using environment variables for configuration"
     if [ -z "${SAFEWAY_ACCOUNT_MAIL_TO}" ] \
@@ -22,7 +22,7 @@ else
 fi
 
 if [ -d "${DEBUG_DIR}" ]; then
-    args="${args} --debug-dir ${DEBUG_DIR}"
+    args="${args} --debug-dir \"${DEBUG_DIR}\""
 fi
 
 mkdir -vp /etc/cron.d /var/spool/cron/crontabs


### PR DESCRIPTION
This makes two changes to Docker-based deployments:

* Add quotes in the generated `crontab` for the `SAFEWAY_ACCOUNTS_FILE` and `DEBUG_DIR` environment variable values
* Add a new environment variable `EXTRA_ARGS` for passing additional arbitrary arguments to `safeway-coupons`

Additionally, this improves the documentation around the existing time zone defaults and behavior in `README.md`.

Implements parts 2 and 3 of https://github.com/smkent/safeway-coupons/issues/88.