### PR TITLE
Add `--sendmail` argument for custom sendmail path, arguments

### DIFF
--- a/safeway_coupons/app.py
+++ b/safeway_coupons/app.py
@@ -1,4 +1,5 @@
 import argparse
+import shlex
 import sys
 import traceback
 from http.client import HTTPConnection
@@ -54,6 +55,17 @@ def _parse_args() -> argparse.Namespace:
         help="Maximum number of coupons to clip (default: all)",
     )
     arg_parser.add_argument(
+        "--sendmail",
+        metavar="path/to/sendmail",
+        dest="sendmail",
+        type=shlex.split,
+        default="/usr/sbin/sendmail",
+        help=(
+            "Path to sendmail and any additional arguments to use when "
+            "sending email (default: %(default)s)"
+        ),
+    )
+    arg_parser.add_argument(
         "-n",
         "--no-email",
         dest="send_email",
@@ -99,6 +111,7 @@ def main() -> None:
         HTTPConnection.debuglevel = 1
     sc = SafewayCoupons(
         send_email=args.send_email,
+        sendmail=args.sendmail,
         debug_level=args.debug_level,
         debug_dir=Path(args.debug_dir) if args.debug_dir else None,
         sleep_level=args.sleep_level,

--- a/safeway_coupons/email.py
+++ b/safeway_coupons/email.py
@@ -12,6 +12,7 @@ from .models import Offer
 
 
 def _send_email(
+    sendmail: List[str],
     account: Account,
     subject: str,
     mail_message: List[str],
@@ -46,13 +47,13 @@ def _send_email(
             subtype=sub,
         )
     p = subprocess.Popen(
-        ["/usr/sbin/sendmail", "-f", account.mail_to, "-t"],
-        stdin=subprocess.PIPE,
+        sendmail + ["-f", account.mail_to, "-t"], stdin=subprocess.PIPE
     )
     p.communicate(bytes(msg.as_string(), "UTF-8"))
 
 
 def email_clip_results(
+    sendmail: List[str],
     account: Account,
     offers: List[Offer],
     error: Optional[Error],
@@ -72,10 +73,13 @@ def email_clip_results(
         mail_message.append(
             f"    {offer_type.name}: {len(offers_this_type)} coupons"
         )
-    _send_email(account, mail_subject, mail_message, debug_level, send_email)
+    _send_email(
+        sendmail, account, mail_subject, mail_message, debug_level, send_email
+    )
 
 
 def email_error(
+    sendmail: List[str],
     account: Account,
     error: Error,
     debug_level: int,
@@ -91,6 +95,7 @@ def email_error(
         for offer in error.clipped_offers:
             mail_message += str(offer)
     _send_email(
+        sendmail,
         account,
         mail_subject,
         mail_message,

--- a/safeway_coupons/safeway.py
+++ b/safeway_coupons/safeway.py
@@ -15,6 +15,7 @@ class SafewayCoupons:
     def __init__(
         self,
         send_email: bool = True,
+        sendmail: Optional[List[str]] = None,
         debug_level: int = 0,
         debug_dir: Optional[Path] = None,
         sleep_level: int = 0,
@@ -23,6 +24,7 @@ class SafewayCoupons:
         max_clip_errors: int = CLIP_ERROR_MAX,
     ) -> None:
         self.send_email = send_email
+        self.sendmail = sendmail or ["/usr/sbin/sendmail"]
         self.debug_level = debug_level
         self.debug_dir = debug_dir
         self.sleep_level = sleep_level
@@ -82,6 +84,7 @@ class SafewayCoupons:
 
             print(f"Clipped {len(clipped_offers)} coupons")
             email_clip_results(
+                self.sendmail,
                 account,
                 clipped_offers,
                 error=None,
@@ -91,6 +94,7 @@ class SafewayCoupons:
             )
         except Error as e:
             email_error(
+                self.sendmail,
                 account,
                 error=e,
                 debug_level=self.debug_level,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -57,6 +57,7 @@ def test_app_error(
             [],
             dict(
                 send_email=True,
+                sendmail=["/usr/sbin/sendmail"],
                 debug_level=0,
                 debug_dir=Path("."),
                 sleep_level=0,
@@ -68,6 +69,7 @@ def test_app_error(
             ["-d", "-d", "-SS"],
             dict(
                 send_email=True,
+                sendmail=["/usr/sbin/sendmail"],
                 debug_level=2,
                 debug_dir=Path("."),
                 sleep_level=2,
@@ -76,9 +78,44 @@ def test_app_error(
             ),
         ),
         (
+            ["--sendmail", "/my/special/sendmail"],
+            dict(
+                send_email=True,
+                sendmail=["/my/special/sendmail"],
+                debug_level=0,
+                debug_dir=Path("."),
+                sleep_level=0,
+                dry_run=False,
+                max_clip_count=0,
+            ),
+        ),
+        (
+            [
+                "--sendmail",
+                (
+                    "/my/special/sendmail "
+                    '--do-the-thing "with an argument value with spaces"'
+                ),
+            ],
+            dict(
+                send_email=True,
+                sendmail=[
+                    "/my/special/sendmail",
+                    "--do-the-thing",
+                    "with an argument value with spaces",
+                ],
+                debug_level=0,
+                debug_dir=Path("."),
+                sleep_level=0,
+                dry_run=False,
+                max_clip_count=0,
+            ),
+        ),
+        (
             ["-n"],
             dict(
                 send_email=False,
+                sendmail=["/usr/sbin/sendmail"],
                 debug_level=0,
                 debug_dir=Path("."),
                 sleep_level=0,
@@ -90,6 +127,7 @@ def test_app_error(
             ["-p", "--max-clip", "42"],
             dict(
                 send_email=True,
+                sendmail=["/usr/sbin/sendmail"],
                 debug_level=0,
                 debug_dir=Path("."),
                 sleep_level=0,
@@ -101,6 +139,8 @@ def test_app_error(
     ids=[
         "Default values",
         "Debug and sleep levels 2",
+        "Custom sendmail",
+        "Custom sendmail with arguments",
         "No email",
         "Dry run and max clip count",
     ],


### PR DESCRIPTION
The `--sendmail` argument value is processed with [`shlex.split`](https://docs.python.org/3/library/shlex.html#shlex.split) to preserve quoted argument values.

This implements the sendmail configuration feature request in https://github.com/smkent/safeway-coupons/issues/88.